### PR TITLE
Fix the _inlines element rendering failed

### DIFF
--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -191,10 +191,13 @@ class MarkdownBuilder implements md.NodeVisitor {
     // If there is one inline element left behind, wrap that in a column and add it to the block.
     if (_inlines.length == 1) {
       List<Widget> widgets = _inlines.first.children;
-      Widget col = Column(
-        children: widgets,
-      );
-      _blocks.single.children.add(col);
+      if(widgets.length == 0) _inlines.clear();
+      else{
+        Widget col = Column(
+          children: widgets,
+        );
+        _blocks.single.children.add(col);
+      }
     }
 
 

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -187,6 +187,17 @@ class MarkdownBuilder implements md.NodeVisitor {
       assert(_blocks.length == 1);
       node.accept(this);
     }
+    
+    // If there is one inline element left behind, wrap that in a column and add it to the block.
+    if (_inlines.length == 1) {
+      List<Widget> widgets = _inlines.first.children;
+      Widget col = Column(
+        children: widgets,
+      );
+      _blocks.single.children.add(col);
+    }
+
+
 
     assert(_tables.isEmpty);
     assert(_inlines.isEmpty);


### PR DESCRIPTION
This fixes the issue, when the markdown has any inline element (image, italic, bold, etc.) at the end of markdown , it failed to create an group and builder throw the error.

The main issue is referenced in [https://github.com/CircuitVerse/mobile-app/issues/216](https://github.com/CircuitVerse/mobile-app/issues/216) and [https://github.com/CircuitVerse/mobile-app/pull/249](https://github.com/CircuitVerse/mobile-app/pull/249)