### PR TITLE
Clear the list of _inlines after aadding last element in list

### DIFF
--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -189,15 +189,15 @@ class MarkdownBuilder implements md.NodeVisitor {
     }
     
     // If there is one inline element left behind, wrap that in a column and add it to the block.
-    if (_inlines.length == 1) {
+    if (_inlines.length >= 1) {
       List<Widget> widgets = _inlines.first.children;
-      if(widgets.length == 0) _inlines.clear();
-      else{
+      if(widgets.length > 0){
         Widget col = Column(
           children: widgets,
         );
         _blocks.single.children.add(col);
       }
+      _inlines.clear();
     }
 
 


### PR DESCRIPTION
The markdown related bug has been fixed in #39 
I have forget to push the last commit, which clear the array after adding the last element in children.
This part does not create issue in release, but will show warning in debug mode of app.

So, creating this pull request.